### PR TITLE
Add CSV/Excel support, Streamlit UI, multithreading, and error handling

### DIFF
--- a/TheScrapper.py
+++ b/TheScrapper.py
@@ -1,3 +1,4 @@
+import csv
 import json
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
@@ -32,6 +33,8 @@ def build_parser() -> ArgumentParser:
     p.add_argument("-s",   "--socials",        action="store_true", help="Extract and print social media links.")
     p.add_argument("--social-extract",         action="store_true", help="Fetch detailed info for found social media links (implies --socials).")
     p.add_argument("-o",   "--output",         action="store_true", help="Save output to a JSON file.")
+    p.add_argument("--csv",                    help="CSV or Excel (.xlsx) file with URLs. Reads URLs and writes results back.")
+    p.add_argument("--csv-column",             default="url", help="Column name containing URLs in the CSV/Excel file (default: 'url').")
     p.add_argument("-v",   "--verbose",        action="store_true", help="Verbose output.")
     return p
 
@@ -99,21 +102,137 @@ def save_output(data: dict | list, name: str) -> None:
     file_name = name.lower().replace("http://", "").replace("https://", "").replace("/", "")
     out_path = Path("output") / f"{file_name}.json"
     out_path.write_text(json.dumps(data, indent=4))
-    print(f"Saved → {out_path}")
+    print(f"Saved -> {out_path}")
+
+
+def save_csv_output(results: list, output_path: str) -> None:
+    """Save scrape results to a CSV file."""
+    Path("output").mkdir(exist_ok=True)
+    out_path = Path("output") / output_path
+
+    fieldnames = ["URL", "Emails", "Phone Numbers", "Social Media"]
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.DictWriter(f, fieldnames=fieldnames)
+        writer.writeheader()
+        for result in results:
+            writer.writerow({
+                "URL": result.get("Target", ""),
+                "Emails": "; ".join(result.get("E-Mails", [])),
+                "Phone Numbers": "; ".join(result.get("Numbers", [])),
+                "Social Media": "; ".join(result.get("SocialMedia", [])),
+            })
+    print(f"Saved -> {out_path}")
+
+
+def read_csv_urls(file_path: str, column: str) -> list:
+    """Read URLs from a CSV file column."""
+    urls = []
+    with open(file_path, "r", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        if column not in reader.fieldnames:
+            raise SystemExit(
+                f"Column '{column}' not found in CSV. "
+                f"Available columns: {', '.join(reader.fieldnames)}"
+            )
+        for row in reader:
+            url = row[column].strip()
+            if url:
+                urls.append(url)
+    return urls
+
+
+def read_excel_urls(file_path: str, column: str) -> list:
+    """Read URLs from an Excel (.xlsx) file column."""
+    try:
+        from openpyxl import load_workbook
+    except ImportError:
+        raise SystemExit("openpyxl is required for Excel support. Install it with: pip install openpyxl")
+
+    wb = load_workbook(file_path, read_only=True)
+    ws = wb.active
+    headers = [cell.value for cell in next(ws.iter_rows(min_row=1, max_row=1))]
+
+    if column not in headers:
+        raise SystemExit(
+            f"Column '{column}' not found in Excel file. "
+            f"Available columns: {', '.join(str(h) for h in headers if h)}"
+        )
+
+    col_idx = headers.index(column)
+    urls = []
+    for row in ws.iter_rows(min_row=2):
+        val = row[col_idx].value
+        if val and str(val).strip():
+            urls.append(str(val).strip())
+    wb.close()
+    return urls
+
+
+def save_excel_output(results: list, output_path: str) -> None:
+    """Save scrape results to an Excel (.xlsx) file."""
+    try:
+        from openpyxl import Workbook
+    except ImportError:
+        raise SystemExit("openpyxl is required for Excel support. Install it with: pip install openpyxl")
+
+    Path("output").mkdir(exist_ok=True)
+    out_path = Path("output") / output_path
+
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Scrape Results"
+    ws.append(["URL", "Emails", "Phone Numbers", "Social Media"])
+
+    for result in results:
+        ws.append([
+            result.get("Target", ""),
+            "; ".join(result.get("E-Mails", [])),
+            "; ".join(result.get("Numbers", [])),
+            "; ".join(result.get("SocialMedia", [])),
+        ])
+
+    wb.save(out_path)
+    print(f"Saved -> {out_path}")
 
 
 def main() -> None:
     args = build_parser().parse_args()
 
-    if not args.url and not args.urls:
-        raise SystemExit("Please add --url or --urls")
+    if not args.url and not args.urls and not args.csv:
+        raise SystemExit("Please add --url, --urls, or --csv")
 
     if not args.banner:
         print(BANNER)
 
     verbose = print if args.verbose else lambda *_: None
 
-    if args.url:
+    if args.csv:
+        csv_path = Path(args.csv)
+        if not csv_path.exists():
+            raise SystemExit(f"File not found: {args.csv}")
+
+        is_excel = csv_path.suffix.lower() in (".xlsx", ".xls")
+
+        if is_excel:
+            raw_urls = read_excel_urls(args.csv, args.csv_column)
+        else:
+            raw_urls = read_csv_urls(args.csv, args.csv_column)
+
+        results = []
+        for raw in raw_urls:
+            url = normalize_url(raw)
+            verbose(f"Scraping {url}")
+            result = scrape(url, args)
+            verbose("Done")
+            print_result(result, args)
+            results.append(result)
+
+        if is_excel:
+            save_excel_output(results, csv_path.stem + "_results.xlsx")
+        else:
+            save_csv_output(results, csv_path.stem + "_results.csv")
+
+    elif args.url:
         url = normalize_url(args.url)
         requests.get(url)
         verbose("Scraping started")

--- a/TheScrapper.py
+++ b/TheScrapper.py
@@ -1,6 +1,9 @@
 import csv
 import json
+import sys
+import threading
 from argparse import ArgumentParser, Namespace
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import requests
@@ -36,6 +39,7 @@ def build_parser() -> ArgumentParser:
     p.add_argument("--csv",                    help="CSV or Excel (.xlsx) file with URLs. Reads URLs and writes results back.")
     p.add_argument("--csv-column",             default="url", help="Column name containing URLs in the CSV/Excel file (default: 'url').")
     p.add_argument("-v",   "--verbose",        action="store_true", help="Verbose output.")
+    p.add_argument("-t",   "--threads",        type=int, default=5, help="Number of concurrent threads for batch scraping (default: 5).")
     return p
 
 
@@ -124,6 +128,33 @@ def save_csv_output(results: list, output_path: str) -> None:
     print(f"Saved -> {out_path}")
 
 
+class IncrementalCsvWriter:
+    """Writes results to CSV incrementally so progress isn't lost on crash."""
+
+    def __init__(self, output_path: str):
+        Path("output").mkdir(exist_ok=True)
+        self.out_path = Path("output") / output_path
+        self._fieldnames = ["URL", "Emails", "Phone Numbers", "Social Media"]
+        self._file = open(self.out_path, "w", newline="", encoding="utf-8")
+        self._writer = csv.DictWriter(self._file, fieldnames=self._fieldnames)
+        self._writer.writeheader()
+        self._lock = threading.Lock()
+
+    def write(self, result: dict) -> None:
+        with self._lock:
+            self._writer.writerow({
+                "URL": result.get("Target", ""),
+                "Emails": "; ".join(result.get("E-Mails", [])),
+                "Phone Numbers": "; ".join(result.get("Numbers", [])),
+                "Social Media": "; ".join(result.get("SocialMedia", [])),
+            })
+            self._file.flush()
+
+    def close(self) -> None:
+        self._file.close()
+        print(f"Saved -> {self.out_path}")
+
+
 def read_csv_urls(file_path: str, column: str) -> list:
     """Read URLs from a CSV file column."""
     urls = []
@@ -195,6 +226,42 @@ def save_excel_output(results: list, output_path: str) -> None:
     print(f"Saved -> {out_path}")
 
 
+def scrape_batch(urls: list, args: Namespace, verbose, csv_writer=None) -> list:
+    """Scrape multiple URLs concurrently using threads."""
+    results = {}
+    total = len(urls)
+    completed = 0
+    failed = 0
+    lock = threading.Lock()
+
+    def _scrape_one(url):
+        try:
+            return url, scrape(url, args)
+        except requests.exceptions.RequestException:
+            return url, None
+
+    with ThreadPoolExecutor(max_workers=args.threads) as pool:
+        futures = {pool.submit(_scrape_one, url): url for url in urls}
+        for future in as_completed(futures):
+            url, result = future.result()
+            with lock:
+                completed += 1
+                if result is not None:
+                    results[url] = result
+                    if csv_writer:
+                        csv_writer.write(result)
+                else:
+                    failed += 1
+                sys.stderr.write(
+                    f"\r[{completed}/{total}] Done: {completed - failed} | Failed: {failed}  "
+                )
+                sys.stderr.flush()
+
+    sys.stderr.write("\n")
+    # Preserve original URL order in output
+    return [results[url] for url in urls if url in results]
+
+
 def main() -> None:
     args = build_parser().parse_args()
 
@@ -218,42 +285,44 @@ def main() -> None:
         else:
             raw_urls = read_csv_urls(args.csv, args.csv_column)
 
-        results = []
-        for raw in raw_urls:
-            url = normalize_url(raw)
-            verbose(f"Scraping {url}")
-            result = scrape(url, args)
-            verbose("Done")
-            print_result(result, args)
-            results.append(result)
+        urls = [normalize_url(raw) for raw in raw_urls]
+        verbose(f"Scraping {len(urls)} URLs with {args.threads} threads...")
 
         if is_excel:
+            results = scrape_batch(urls, args, verbose)
+            for result in results:
+                print_result(result, args)
             save_excel_output(results, csv_path.stem + "_results.xlsx")
         else:
-            save_csv_output(results, csv_path.stem + "_results.csv")
+            writer = IncrementalCsvWriter(csv_path.stem + "_results.csv")
+            results = scrape_batch(urls, args, verbose, csv_writer=writer)
+            writer.close()
+            for result in results:
+                print_result(result, args)
 
     elif args.url:
         url = normalize_url(args.url)
-        requests.get(url)
         verbose("Scraping started")
-        result = scrape(url, args)
+        try:
+            result = scrape(url, args)
+        except requests.exceptions.RequestException as e:
+            raise SystemExit(f"[!] Failed to scrape {url}: {e}")
         verbose("Done")
         print_result(result, args)
         if args.output:
             save_output(result, url)
 
     else:
-        results = []
-        for raw in Path(args.urls).read_text().splitlines():
-            url = normalize_url(raw.strip())
-            if not url:
-                continue
-            requests.get(url)
-            verbose(f"Scraping {url}")
-            result = scrape(url, args)
-            verbose("Done")
+        raw_urls = [
+            raw.strip() for raw in Path(args.urls).read_text().splitlines()
+            if raw.strip()
+        ]
+        urls = [normalize_url(raw) for raw in raw_urls]
+        verbose(f"Scraping {len(urls)} URLs with {args.threads} threads...")
+        results = scrape_batch(urls, args, verbose)
+
+        for result in results:
             print_result(result, args)
-            results.append(result)
 
         if args.output:
             save_output(results, args.urls.replace("/", "_"))

--- a/app.py
+++ b/app.py
@@ -1,0 +1,206 @@
+import io
+import threading
+from argparse import Namespace
+from pathlib import Path
+
+import streamlit as st
+import pandas as pd
+
+from modules.scrapper import Scrapper
+from modules.info_reader import InfoReader
+from TheScrapper import normalize_url, scrape
+
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import requests
+
+
+def scrape_urls(urls: list, args: Namespace, progress_bar, status_text) -> list:
+    """Scrape URLs with threads, updating Streamlit progress."""
+    results = {}
+    total = len(urls)
+    completed = 0
+    failed = 0
+    lock = threading.Lock()
+
+    def _scrape_one(url):
+        try:
+            return url, scrape(url, args)
+        except requests.exceptions.RequestException:
+            return url, None
+
+    with ThreadPoolExecutor(max_workers=args.threads) as pool:
+        futures = {pool.submit(_scrape_one, url): url for url in urls}
+        for future in as_completed(futures):
+            url, result = future.result()
+            with lock:
+                completed += 1
+                if result is not None:
+                    results[url] = result
+                else:
+                    failed += 1
+                progress_bar.progress(completed / total)
+                status_text.text(f"[{completed}/{total}] Done: {completed - failed} | Failed: {failed}")
+
+    return [results[url] for url in urls if url in results]
+
+
+def results_to_dataframe(results: list) -> pd.DataFrame:
+    """Convert scrape results to a pandas DataFrame."""
+    rows = []
+    for r in results:
+        rows.append({
+            "URL": r.get("Target", ""),
+            "Emails": "; ".join(r.get("E-Mails", [])),
+            "Phone Numbers": "; ".join(r.get("Numbers", [])),
+            "Social Media": "; ".join(r.get("SocialMedia", [])),
+        })
+    return pd.DataFrame(rows)
+
+
+def to_excel_bytes(df: pd.DataFrame) -> bytes:
+    """Convert DataFrame to Excel bytes for download."""
+    buf = io.BytesIO()
+    df.to_excel(buf, index=False, engine="openpyxl")
+    return buf.getvalue()
+
+
+# --- Page config ---
+st.set_page_config(page_title="TheScrapper", page_icon="🔍", layout="wide")
+
+st.markdown(
+    "<h1 style='text-align: center;'>TheScrapper</h1>"
+    "<p style='text-align: center; color: gray;'>Extract emails, phone numbers & social media links from websites</p>",
+    unsafe_allow_html=True,
+)
+
+st.divider()
+
+# --- Sidebar: Options ---
+with st.sidebar:
+    st.header("Options")
+
+    st.subheader("Extract")
+    extract_emails = st.checkbox("Emails", value=True)
+    extract_numbers = st.checkbox("Phone Numbers", value=True)
+    extract_socials = st.checkbox("Social Media", value=True)
+
+    st.subheader("Settings")
+    crawl = st.checkbox("Crawl links on each page", value=False)
+    threads = st.slider("Threads", min_value=1, max_value=50, value=10)
+
+# Build a fake Namespace matching what scrape() expects
+args = Namespace(
+    email=extract_emails and not (extract_emails and extract_numbers and extract_socials),
+    number=extract_numbers and not (extract_emails and extract_numbers and extract_socials),
+    socials=extract_socials and not (extract_emails and extract_numbers and extract_socials),
+    social_extract=False,
+    crawl=crawl,
+    threads=threads,
+)
+# If all three are checked, set all to False so scrape() defaults to extracting everything
+if extract_emails and extract_numbers and extract_socials:
+    args.email = False
+    args.number = False
+    args.socials = False
+
+# --- Input ---
+tab_single, tab_batch = st.tabs(["Single URL", "Batch (CSV / Excel)"])
+
+with tab_single:
+    url_input = st.text_input("Enter a URL", placeholder="https://example.com")
+    run_single = st.button("Scrape", key="single", use_container_width=True)
+
+with tab_batch:
+    uploaded_file = st.file_uploader("Upload CSV or Excel file", type=["csv", "xlsx", "xls"])
+    col_name = st.text_input("Column name containing URLs", value="url")
+    run_batch = st.button("Scrape All", key="batch", use_container_width=True)
+
+# --- Processing ---
+
+if run_single and url_input:
+    url = normalize_url(url_input.strip())
+    with st.spinner(f"Scraping {url}..."):
+        try:
+            result = scrape(url, args)
+        except requests.exceptions.RequestException as e:
+            st.error(f"Failed to scrape: {e}")
+            st.stop()
+
+    st.success("Done!")
+    df = results_to_dataframe([result])
+    st.dataframe(df, use_container_width=True, hide_index=True)
+
+    # --- Export ---
+    st.subheader("Export")
+    col1, col2 = st.columns(2)
+    with col1:
+        st.download_button(
+            "Download CSV",
+            df.to_csv(index=False).encode("utf-8"),
+            file_name="result.csv",
+            mime="text/csv",
+            use_container_width=True,
+        )
+    with col2:
+        st.download_button(
+            "Download Excel",
+            to_excel_bytes(df),
+            file_name="result.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            use_container_width=True,
+        )
+
+elif run_batch and uploaded_file:
+    # Read URLs from uploaded file
+    try:
+        if uploaded_file.name.endswith((".xlsx", ".xls")):
+            input_df = pd.read_excel(uploaded_file, engine="openpyxl")
+        else:
+            input_df = pd.read_csv(uploaded_file)
+    except Exception as e:
+        st.error(f"Could not read file: {e}")
+        st.stop()
+
+    if col_name not in input_df.columns:
+        st.error(f"Column **'{col_name}'** not found. Available columns: {', '.join(input_df.columns)}")
+        st.stop()
+
+    raw_urls = input_df[col_name].dropna().astype(str).str.strip().tolist()
+    raw_urls = [u for u in raw_urls if u]
+
+    if not raw_urls:
+        st.warning("No URLs found in the specified column.")
+        st.stop()
+
+    urls = [normalize_url(u) for u in raw_urls]
+
+    st.info(f"Scraping **{len(urls)}** URLs with **{threads}** threads...")
+    progress_bar = st.progress(0)
+    status_text = st.empty()
+
+    results = scrape_urls(urls, args, progress_bar, status_text)
+
+    st.success(f"Completed! {len(results)}/{len(urls)} URLs scraped successfully.")
+
+    df = results_to_dataframe(results)
+    st.dataframe(df, use_container_width=True, hide_index=True)
+
+    # --- Export ---
+    st.subheader("Export")
+    col1, col2 = st.columns(2)
+    with col1:
+        st.download_button(
+            "Download CSV",
+            df.to_csv(index=False).encode("utf-8"),
+            file_name="results.csv",
+            mime="text/csv",
+            use_container_width=True,
+        )
+    with col2:
+        st.download_button(
+            "Download Excel",
+            to_excel_bytes(df),
+            file_name="results.xlsx",
+            mime="application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+            use_container_width=True,
+        )

--- a/modules/info_reader.py
+++ b/modules/info_reader.py
@@ -28,7 +28,7 @@ class InfoReader:
         self.content: dict = content
         self.social_path: str = social_path
         self.res: dict = {
-            "phone": "/^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,7}$/gm",
+            "phone": r"/^[\+]?[(]?[0-9]{3}[)]?[-\s\.]?[0-9]{3}[-\s\.]?[0-9]{4,7}$/gm",
             "email": r"(^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$)"
         }
 

--- a/modules/scrapper.py
+++ b/modules/scrapper.py
@@ -3,6 +3,12 @@ import requests
 from requests.models import Response
 from bs4 import BeautifulSoup
 
+# Shared session for connection pooling and default headers
+_session = requests.Session()
+_session.headers.update({
+    "User-Agent": "Mozilla/5.0 (compatible; TheScrapper/1.0; +https://github.com/AhmadShahzad/TheScrapper)"
+})
+
 
 class Scrapper:
     """
@@ -22,6 +28,7 @@ class Scrapper:
         self.urls = []
         self.contents = contents
         self.crawl = crawl
+        self._page_text = None
 
     def clean(self) -> list:
         """clean function
@@ -48,6 +55,15 @@ class Scrapper:
 
         return contents
 
+    def _fetch(self) -> str | None:
+        """Fetch the page once and cache the result."""
+        if self._page_text is None:
+            try:
+                self._page_text = _session.get(self.url, timeout=15).text
+            except requests.exceptions.RequestException:
+                self._page_text = ""
+        return self._page_text or None
+
     def getURLs(self) -> list:
         """getURLs function
 
@@ -56,7 +72,9 @@ class Scrapper:
         """
 
         urls: list = []
-        content: str = requests.get(self.url).text
+        content = self._fetch()
+        if content is None:
+            return urls
         soup = BeautifulSoup(content, "html.parser")
         for link in soup.find_all('a'):
             if link.get("href") is not None:
@@ -80,12 +98,13 @@ class Scrapper:
             for url in urls:
                 try:
                     if url is not None:
-                        req: Response = requests.get(url)
+                        req: Response = _session.get(url, timeout=15)
                         contents.append(req.text)
-                except requests.exceptions.MissingSchema:
+                except requests.exceptions.RequestException:
                     pass
         else:
-            req: Response = requests.get(self.url)
-            contents.append(req.text)
+            page = self._fetch()
+            if page:
+                contents.append(page)
         contents = Scrapper(contents=contents).clean()
         return {"text": contents, "urls": urls}

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ beautifulsoup4
 argparse
 socid-extractor
 openpyxl
+streamlit
+pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ requests
 beautifulsoup4
 argparse
 socid-extractor
+openpyxl


### PR DESCRIPTION
## Summary

  ### CSV & Excel Support
  - Added `--csv` flag to accept CSV or Excel (.xlsx) files containing URLs
  - Added `--csv-column` flag to specify URL column name (defaults to `url`)
  - Auto-detects file type by extension and outputs results in matching format
  - Added `openpyxl` dependency for Excel support

  ### Streamlit Web UI
  - Added `app.py` — a minimal web interface for all scraping features
  - Single URL and batch (CSV/Excel) scraping via browser
  - Live progress bar for batch operations
  - Download results as CSV or Excel directly from the UI

  ### Multithreaded Batch Scraping
  - Added `-t`/`--threads` flag to control concurrent threads (default: 5)
  - Uses `ThreadPoolExecutor` for parallel URL scraping
  - Real-time progress indicator: `[847/1600] Done: 831 | Failed: 16`
  - Incremental CSV saving — results flush to disk as they complete, so a crash
  doesn't lose progress

  ### Error Handling & Performance
  - Fixed crash on `TooManyRedirects`, `ConnectionError`, `Timeout` and other
  request failures
  - Batch mode now skips failed URLs and continues instead of crashing
  - Eliminated duplicate HTTP requests per URL (was fetching each page twice)
  - Added `requests.Session` for TCP connection pooling across threads
  - Added proper User-Agent header to reduce blocks from target sites
  - Added 15s timeout on all HTTP requests to prevent hanging

  ## Usage

  ### Web UI
  ```bash
  streamlit run app.py

  CLI — Batch with threading

  python TheScrapper.py --csv sites.csv --csv-column Website -t 15

  CLI — Single URL

  python TheScrapper.py --url https://example.com

  Test Plan

  - Run streamlit run app.py and verify UI loads at localhost:8501
  - Scrape a single URL via the UI
  - Upload a CSV file and batch scrape via the UI
  - Download results as CSV and Excel from the UI
  - Run CLI with --csv on a file with 5+ URLs and verify threading works
  - Run CLI with a URL that causes a redirect loop (should skip, not crash)
  - Run with -t 1 and -t 20 to verify thread count flag works
  - Verify progress indicator shows during batch scraping
  - Kill mid-run and verify partial results are saved in output/
